### PR TITLE
when worker has terminated before disconnect, don't fork

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,10 @@ function fork(options) {
 
   cluster.on('disconnect', function (worker) {
     disconnectCount++;
+    if (worker.isDead && worker.isDead()) {
+      // worker has terminated before disconnect
+      return;
+    }
     disconnects[worker.process.pid] = new Date();
     if (allow()) {
       cluster.fork();


### PR DESCRIPTION
fix #6 