### PR TITLE
update reachReforkLimit usage in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,17 +64,17 @@ cfork({
   // logger what you want
 });
 
-// if you do not listen to this event
-// cfork will listen it and output the error message to stderr
-process.on('uncaughtException', function (err) {
-  // do what you want
-});
-
 // emit when reach refork times limit
 .on('reachReforkLimit', function () {
   // do what you want
 });
 ```
+
+// if you do not listen to this event
+// cfork will listen it and output the error message to stderr
+process.on('uncaughtException', function (err) {
+  // do what you want
+});
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ cfork({
 .on('reachReforkLimit', function () {
   // do what you want
 });
-```
 
 // if you do not listen to this event
 // cfork will listen it and output the error message to stderr
 process.on('uncaughtException', function (err) {
   // do what you want
 });
+```
 
 ### Options
 


### PR DESCRIPTION
The `reachReforkLimit` event is on `cluster`, not `process`