### PR TITLE
Add environment variables support for workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ process.on('uncaughtException', function (err) {
 - **limit**: limit refork times within the `duration`, default is `60`
 - **duration**: default is `60000`, one minute (so, the `refork times` < `limit / duration`)
 - **autoCoverage**: auto fork with istanbul when `running_under_istanbul` env set, default is `false`
+- **env**: attach some environment variable key-value pairs to the worker / slave process, default to an empty object.
 
 ## License
 

--- a/fixtures/master.js
+++ b/fixtures/master.js
@@ -14,6 +14,9 @@ cfork({
   count: 4,
   duration: 60000,
   autoCoverage: true,
+  env: {
+    CFORK_ENV_TEST: '😂',
+  },
 })
 .on('fork', function (worker) {
   console.warn('[%s] [worker:%d] new worker start', Date(), worker.process.pid);

--- a/fixtures/slave.js
+++ b/fixtures/slave.js
@@ -11,6 +11,9 @@ var app = http.createServer(function (req, res) {
   if (req.url === '/exit') {
     process.exit(0);
   }
+  if (req.url === '/env') {
+    return res.end(process.env.CFORK_ENV_TEST);
+  }
   res.end(req.method + ' ' + req.url);
 }).listen(port);
 

--- a/fixtures/worker.js
+++ b/fixtures/worker.js
@@ -21,6 +21,9 @@ var app = http.createServer(function (req, res) {
   if (req.url === '/exit') {
     process.exit(0);
   }
+  if (req.url === '/env') {
+    return res.end(process.env.CFORK_ENV_TEST);
+  }
   res.end(req.method + ' ' + req.url);
 }).listen(port);
 

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ function fork(options) {
   var limit = options.limit || 60;
   var duration = options.duration || 60000; // 1 min
   var reforks = [];
+  var attachedEnv = options.env || {};
   var newWorker;
 
   if (options.exec) {
@@ -241,6 +242,6 @@ function fork(options) {
       cluster.settings = settings;
       cluster.setupMaster();
     }
-    return cluster.fork();
+    return cluster.fork(attachedEnv);
   }
 }

--- a/test/cfork.test.js
+++ b/test/cfork.test.js
@@ -65,6 +65,20 @@ describe('cfork.test.js', function () {
     });
   });
 
+  it('should get correct env value', function (done) {
+    urllib.request('http://localhost:1984/env', function (err, body, resp) {
+      should.ifError(err);
+      body.toString().should.equal('😂');
+      resp.statusCode.should.equal(200);
+      urllib.request('http://localhost:1985/env', function (err, body, resp) {
+        should.ifError(err);
+        body.toString().should.equal('😂');
+        resp.statusCode.should.equal(200);
+        done();
+      });
+    });
+  });
+
   it('should slave error and refork', function (done) {
     urllib.request('http://localhost:1985/error', function (err) {
       should.exist(err);
@@ -72,7 +86,12 @@ describe('cfork.test.js', function () {
         should.not.exist(err);
         body.toString().should.equal('GET /');
         res.statusCode.should.equal(200);
-        done();
+        urllib.request('http://localhost:1985/env', function (err, body, resp) {
+          should.ifError(err);
+          body.toString().should.equal('😂');
+          resp.statusCode.should.equal(200);
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
There's a parameter in `cluster.fork()` called `env`, it used to be the attached environment variable.