### PR TITLE
feat: support serialization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ process.on('uncaughtException', err => {
 - **autoCoverage**: auto fork with istanbul when `running_under_istanbul` env set, default is `false`
 - **env**: attach some environment variable key-value pairs to the worker / slave process, default to an empty object.
 - **windowsHide**: Hide the forked processes console window that would normally be created on Windows systems, default to false.
+- **serialization**: Specify the kind of serialization used for sending messages between processes. Possible values are 'json' and 'advanced'. See Advanced serialization for child_process for more details. Default: false.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function fork(options) {
       opts.args = args;
     }
 
-    cluster.setupMaster(opts);
+    cluster.setupPrimary(opts);
   }
 
   var disconnects = {};
@@ -263,7 +263,7 @@ function fork(options) {
   function forkWorker(settings) {
     if (settings) {
       cluster.settings = settings;
-      cluster.setupMaster();
+      cluster.setupPrimary();
     }
     return cluster.fork(attachedEnv);
   }

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function fork(options) {
       opts.args = args;
     }
 
-    cluster.setupPrimary(opts);
+    setupPrimary(opts);
   }
 
   var disconnects = {};
@@ -267,8 +267,21 @@ function fork(options) {
   function forkWorker(settings) {
     if (settings) {
       cluster.settings = settings;
-      cluster.setupPrimary();
+      setupPrimary();
     }
     return cluster.fork(attachedEnv);
+  }
+
+  /**
+   * used to change the default 'fork' behavior
+   * cluster.setupMaster() is deprecated since v16.0.0，and cluster.setupPrimary() added in v16.0.0
+   */
+  function setupPrimary(opts) {
+    opts = opts || {};
+    if (typeof cluster.setupPrimary === 'function') {
+      cluster.setupPrimary(opts);
+    } else {
+      cluster.setupMaster(opts);
+    }
   }
 }

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ module.exports = fork;
  *   - {Boolean} [refork]  refork when disconect and unexpected exit, default is `true`
  *   - {Boolean} [autoCoverage] auto fork with istanbul when `running_under_istanbul` env set, default is `false`
  *   - {Boolean} [windowsHide] Hide the forked processes console window that would normally be created on Windows systems. Default: false.
+ *   - {String} [serialization] Specify the kind of serialization used for sending messages between processes. Possible values are 'json' and 'advanced'. See Advanced serialization for child_process for more details. Default: false.
  * @return {Cluster}
  */
 
@@ -55,6 +56,9 @@ function fork(options) {
     }
     if (options.windowsHide !== undefined) {
       opts.windowsHide = options.windowsHide;
+    }
+    if (options.serialization !== undefined) {
+      opts.serialization = options.serialization;
     }
 
 


### PR DESCRIPTION
## Description of change
1. rename deprecated setupMaster to setupPrimary
2. support serialization parameter

Fixes https://github.com/node-modules/cfork/issues/114